### PR TITLE
feat: support FeatureDB write_direct via WithDirect option

### DIFF
--- a/dao/feature_view_dao.go
+++ b/dao/feature_view_dao.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -30,6 +31,10 @@ type FeatureViewDao interface {
 	RowCountIds(string) ([]string, int, error)
 	ScanAndIterateData(filter string, ch chan<- string) ([]string, error)
 	WriteFeatures(data []map[string]interface{})
+	// WriteFeaturesDirect synchronously writes rows via FeatureDB's
+	// /write_direct endpoint. Only FeatureViewFeatureDBDao implements
+	// this; other DAOs return an error.
+	WriteFeaturesDirect(data []map[string]interface{}) error
 	WriteFlush()
 }
 
@@ -73,6 +78,10 @@ func (d *UnimplementedFeatureViewDao) ScanAndIterateData(filter string, ch chan<
 }
 
 func (d *UnimplementedFeatureViewDao) WriteFeatures(data []map[string]interface{}) {}
+
+func (d *UnimplementedFeatureViewDao) WriteFeaturesDirect(data []map[string]interface{}) error {
+	return errors.New("WriteFeaturesDirect is only supported by FeatureDB-backed feature views")
+}
 
 func (d *UnimplementedFeatureViewDao) WriteFlush() {}
 

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -1531,14 +1531,6 @@ func (d *FeatureViewFeatureDBDao) WriteFeaturesDirect(data []map[string]interfac
 		return errors.New("WriteFeaturesDirect requires a primary key field on the feature view")
 	}
 
-	// /write_direct only supports FullRowWrite; strip any caller-injected
-	// __insert_mode__ marker to avoid leaking it into the request body.
-	for _, item := range data {
-		if item != nil {
-			delete(item, "__insert_mode__")
-		}
-	}
-
 	const directBatchSize = 200
 	numBatches := (len(data) + directBatchSize - 1) / directBatchSize
 	for i := 0; i < numBatches; i++ {

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -1575,8 +1575,14 @@ func (d *FeatureViewFeatureDBDao) writeFeatureDBDirect(batch []map[string]interf
 
 	response, err := doRequest(false)
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		response, err = doRequest(true)
 		if err != nil {
+			if response != nil {
+				response.Body.Close()
+			}
 			return err
 		}
 	}
@@ -1731,6 +1737,9 @@ func (d *FeatureViewFeatureDBDao) writeFeatureDB(data []map[string]interface{}) 
 
 		response, err := d.featureDBClient.Client.Do(req)
 		if err != nil {
+			if response != nil {
+				response.Body.Close()
+			}
 			url = fmt.Sprintf("%s/api/v1/tables/%s/%s/%s/write", d.featureDBClient.GetCurrentAddress(true), d.database, d.schema, d.table)
 			requestBody = map[string]interface{}{
 				"content":    data,
@@ -1751,6 +1760,9 @@ func (d *FeatureViewFeatureDBDao) writeFeatureDB(data []map[string]interface{}) 
 
 			response, err = d.featureDBClient.Client.Do(req)
 			if err != nil {
+				if response != nil {
+					response.Body.Close()
+				}
 				return err
 			}
 		}

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -1519,6 +1519,165 @@ func (d *FeatureViewFeatureDBDao) WriteFeatures(data []map[string]interface{}) {
 	d.writeData = append(d.writeData, data...)
 }
 
+// WriteFeaturesDirect writes rows synchronously via the FeatureDB /write_direct
+// API, bypassing the async ticker buffer used by WriteFeatures. The endpoint
+// only accepts KV tables with FullRowWrite semantics; PartialFieldWrite and
+// non-KV feature views are rejected by the server.
+func (d *FeatureViewFeatureDBDao) WriteFeaturesDirect(data []map[string]interface{}) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if d.primaryKeyField == "" {
+		return errors.New("WriteFeaturesDirect requires a primary key field on the feature view")
+	}
+
+	// /write_direct only supports FullRowWrite; strip any caller-injected
+	// __insert_mode__ marker to avoid leaking it into the request body.
+	for _, item := range data {
+		if item != nil {
+			delete(item, "__insert_mode__")
+		}
+	}
+
+	const directBatchSize = 200
+	numBatches := (len(data) + directBatchSize - 1) / directBatchSize
+	for i := 0; i < numBatches; i++ {
+		start := i * directBatchSize
+		end := start + directBatchSize
+		if end > len(data) {
+			end = len(data)
+		}
+		if err := d.writeFeatureDBDirect(data[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeFeatureDBDirect issues a single synchronous POST to /write_direct.
+// On transport failure against the public address it falls back to the VPC
+// address, mirroring the behavior of writeFeatureDB.
+func (d *FeatureViewFeatureDBDao) writeFeatureDBDirect(batch []map[string]interface{}) error {
+	requestBody := map[string]interface{}{
+		"content":    batch,
+		"write_mode": constants.FullRowWrite,
+		"key_field":  d.primaryKeyField,
+	}
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return err
+	}
+
+	doRequest := func(useVPC bool) (*http.Response, error) {
+		url := fmt.Sprintf("%s/api/v1/tables/%s/%s/%s/write_direct",
+			d.featureDBClient.GetCurrentAddress(useVPC), d.database, d.schema, d.table)
+		req, reqErr := http.NewRequest("POST", url, bytes.NewReader(body))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", d.featureDBClient.Token)
+		req.Header.Set("Auth", d.signature)
+		return d.featureDBClient.Client.Do(req)
+	}
+
+	response, err := doRequest(false)
+	if err != nil {
+		response, err = doRequest(true)
+		if err != nil {
+			return err
+		}
+	}
+	defer response.Body.Close()
+
+	bodyBytes, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return fmt.Errorf("featuredb write_direct read response failed, StatusCode: %d, error: %v",
+			response.StatusCode, readErr)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		var message string
+		var bodyMap map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &bodyMap); err == nil {
+			if msg, found := bodyMap["message"]; found {
+				message = fmt.Sprintf("%v", msg)
+			}
+		}
+		return fmt.Errorf("featuredb write_direct failed, StatusCode: %d, message: %s",
+			response.StatusCode, message)
+	}
+
+	var resp struct {
+		RequestID string                 `json:"request_id"`
+		Code      string                 `json:"code"`
+		Message   string                 `json:"message"`
+		Data      map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+		return fmt.Errorf("featuredb write_direct decode response failed: %v, body: %s", err, string(bodyBytes))
+	}
+
+	total := toInt(resp.Data["total_count"])
+	success := toInt(resp.Data["success_count"])
+	failKeys := toStringSlice(resp.Data["fail_keys"])
+	errMsgs := toStringSlice(resp.Data["error_messages"])
+
+	if success < total || len(failKeys) > 0 || len(errMsgs) > 0 {
+		var parts []string
+		parts = append(parts, fmt.Sprintf("success_count=%d/total=%d", success, total))
+		if len(failKeys) > 0 {
+			limit := len(failKeys)
+			if limit > 10 {
+				limit = 10
+			}
+			parts = append(parts, fmt.Sprintf("fail_keys(%d)=[%s]",
+				len(failKeys), strings.Join(failKeys[:limit], ",")))
+		}
+		if len(errMsgs) > 0 {
+			limit := len(errMsgs)
+			if limit > 10 {
+				limit = 10
+			}
+			parts = append(parts, fmt.Sprintf("errors=[%s]", strings.Join(errMsgs[:limit], " | ")))
+		}
+		return fmt.Errorf("featuredb write_direct partial failure: %s", strings.Join(parts, "; "))
+	}
+	return nil
+}
+
+func toInt(v interface{}) int {
+	switch x := v.(type) {
+	case float64:
+		return int(x)
+	case int:
+		return x
+	case int64:
+		return int(x)
+	case json.Number:
+		n, _ := x.Int64()
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func toStringSlice(v interface{}) []string {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		} else {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+	}
+	return out
+}
+
 // 实时写入数据
 func (d *FeatureViewFeatureDBDao) writeFeatureDB(data []map[string]interface{}) error {
 	var wg sync.WaitGroup

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -1610,8 +1610,22 @@ func (d *FeatureViewFeatureDBDao) writeFeatureDBDirect(batch []map[string]interf
 		return fmt.Errorf("featuredb write_direct decode response failed: %v, body: %s", err, string(bodyBytes))
 	}
 
-	total := toInt(resp.Data["total_count"])
-	success := toInt(resp.Data["success_count"])
+	// HTTP 200 does not imply business success; the server uses resp.Code to
+	// signal logical errors (e.g. PARAMETER_ERROR, SEVER_ERROR).
+	if resp.Code != "OK" {
+		return fmt.Errorf("featuredb write_direct failed, code: %s, message: %s, request_id: %s",
+			resp.Code, resp.Message, resp.RequestID)
+	}
+	if resp.Data == nil {
+		return fmt.Errorf("featuredb write_direct returned empty data, request_id: %s", resp.RequestID)
+	}
+
+	total, totalOK := toInt(resp.Data["total_count"])
+	success, successOK := toInt(resp.Data["success_count"])
+	if !totalOK || !successOK {
+		return fmt.Errorf("featuredb write_direct returned malformed data (missing total_count/success_count), request_id: %s, data: %v",
+			resp.RequestID, resp.Data)
+	}
 	failKeys := toStringSlice(resp.Data["fail_keys"])
 	errMsgs := toStringSlice(resp.Data["error_messages"])
 
@@ -1638,19 +1652,26 @@ func (d *FeatureViewFeatureDBDao) writeFeatureDBDirect(batch []map[string]interf
 	return nil
 }
 
-func toInt(v interface{}) int {
+// toInt extracts an int from a JSON-decoded value. The second return value
+// distinguishes a missing/unsupported field (false) from a real zero (true),
+// so callers can detect malformed responses instead of silently treating
+// them as success.
+func toInt(v interface{}) (int, bool) {
 	switch x := v.(type) {
 	case float64:
-		return int(x)
+		return int(x), true
 	case int:
-		return x
+		return x, true
 	case int64:
-		return int(x)
+		return int(x), true
 	case json.Number:
-		n, _ := x.Int64()
-		return int(n)
+		n, err := x.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
 	default:
-		return 0
+		return 0, false
 	}
 }
 

--- a/domain/base_feature_view.go
+++ b/domain/base_feature_view.go
@@ -310,16 +310,36 @@ func (f *BaseFeatureView) WriteFeaturesWithMode(data []map[string]interface{}, i
 	f.featureViewDao.WriteFeatures(filteredData)
 }
 
-func (f *BaseFeatureView) WriteFeatures(data []map[string]interface{}) error {
+// WriteFeatures dispatches the rows to the underlying DAO.
+//
+// By default the call is non-blocking: rows are appended to the in-memory
+// buffer that the DAO's background goroutine flushes to the legacy /write
+// endpoint. Pass WithDirect() to bypass the buffer and write synchronously
+// via FeatureDB's /write_direct endpoint, in which case the returned error
+// reflects the result of the HTTP call.
+func (f *BaseFeatureView) WriteFeatures(data []map[string]interface{}, opts ...WriteOption) error {
+	o := resolveWriteOptions(opts)
+	if o.Direct {
+		if o.InsertMode != "" && o.InsertMode != constants.FullRowWrite {
+			return fmt.Errorf("WithDirect only supports %s, got %q", constants.FullRowWrite, o.InsertMode)
+		}
+		return f.featureViewDao.WriteFeaturesDirect(data)
+	}
+	if o.InsertMode != "" {
+		for _, item := range data {
+			if item != nil {
+				item["__insert_mode__"] = o.InsertMode
+			}
+		}
+	}
 	f.featureViewDao.WriteFeatures(data)
 	return nil
 }
 
+// WriteFeaturesWithInsertMode is preserved for backward compatibility and
+// is equivalent to WriteFeatures(data, WithInsertMode(insertMode)).
 func (f *BaseFeatureView) WriteFeaturesWithInsertMode(data []map[string]interface{}, insertMode string) {
-	for _, item := range data {
-		item["__insert_mode__"] = insertMode
-	}
-	f.featureViewDao.WriteFeatures(data)
+	_ = f.WriteFeatures(data, WithInsertMode(insertMode))
 }
 
 func (f *BaseFeatureView) WriteFlush() {

--- a/domain/feature_view.go
+++ b/domain/feature_view.go
@@ -35,7 +35,14 @@ type FeatureView interface {
 	// If stream feature view can iterate the data deliver to the channel
 	ScanAndIterateData(filter string, ch chan<- string) ([]string, error)
 
-	WriteFeatures(data []map[string]interface{}) error
+	// WriteFeatures buffers (or, with WithDirect, synchronously sends)
+	// rows to the underlying online store. WithDirect is currently only
+	// honored by FeatureDB-backed feature views.
+	WriteFeatures(data []map[string]interface{}, opts ...WriteOption) error
+
+	// WriteFeaturesWithInsertMode is a convenience wrapper that forwards
+	// to WriteFeatures with WithInsertMode(insertMode). Retained for
+	// backward compatibility; new callers should prefer WriteFeatures.
 	WriteFeaturesWithInsertMode(data []map[string]interface{}, insertMode string)
 
 	WriteFlush()

--- a/domain/sequence_feature_view.go
+++ b/domain/sequence_feature_view.go
@@ -441,14 +441,24 @@ func (f *SequenceFeatureView) ScanAndIterateData(filter string, ch chan<- string
 }
 
 func (f *SequenceFeatureView) WriteFeaturesWithInsertMode(data []map[string]interface{}, insertMode string) {
-	f.featureViewDao.WriteFeatures(data)
+	_ = f.WriteFeatures(data, WithInsertMode(insertMode))
 }
 
 func (f *SequenceFeatureView) WriteFlush() {
 	f.featureViewDao.WriteFlush()
 }
 
-func (f *SequenceFeatureView) WriteFeatures(data []map[string]interface{}) error {
+// WriteFeatures persists sequence rows through the underlying DAO.
+//
+// Sequence feature views are KKV-shaped on FeatureDB, so the synchronous
+// /write_direct endpoint (which targets KV tables only) is not supported;
+// passing WithDirect returns an error early without sending the request.
+func (f *SequenceFeatureView) WriteFeatures(data []map[string]interface{}, opts ...WriteOption) error {
+	o := resolveWriteOptions(opts)
+	if o.Direct {
+		return errors.New("WithDirect is not supported by sequence feature views; /write_direct only accepts KV tables")
+	}
+
 	sequenceFeatureViewConfig := api.FeatureViewSeqConfig{}
 	err := json.Unmarshal([]byte(f.Config), &sequenceFeatureViewConfig)
 	if err != nil {
@@ -489,6 +499,14 @@ func (f *SequenceFeatureView) WriteFeatures(data []map[string]interface{}) error
 			_ = playTimeValue
 		}
 
+	}
+
+	if o.InsertMode != "" {
+		for _, item := range data {
+			if item != nil {
+				item["__insert_mode__"] = o.InsertMode
+			}
+		}
 	}
 
 	f.featureViewDao.WriteFeatures(data)

--- a/domain/sequence_feature_view.go
+++ b/domain/sequence_feature_view.go
@@ -440,8 +440,11 @@ func (f *SequenceFeatureView) ScanAndIterateData(filter string, ch chan<- string
 	return nil, errors.New("unimplemented")
 }
 
+// WriteFeaturesWithInsertMode preserves the legacy signature. Sequence
+// feature views are always written in full-row mode, so the insertMode
+// argument is intentionally ignored to keep parity with master.
 func (f *SequenceFeatureView) WriteFeaturesWithInsertMode(data []map[string]interface{}, insertMode string) {
-	_ = f.WriteFeatures(data, WithInsertMode(insertMode))
+	f.featureViewDao.WriteFeatures(data)
 }
 
 func (f *SequenceFeatureView) WriteFlush() {
@@ -453,6 +456,8 @@ func (f *SequenceFeatureView) WriteFlush() {
 // Sequence feature views are KKV-shaped on FeatureDB, so the synchronous
 // /write_direct endpoint (which targets KV tables only) is not supported;
 // passing WithDirect returns an error early without sending the request.
+// Sequence rows are always written in full-row mode, so WithInsertMode is
+// ignored.
 func (f *SequenceFeatureView) WriteFeatures(data []map[string]interface{}, opts ...WriteOption) error {
 	o := resolveWriteOptions(opts)
 	if o.Direct {
@@ -499,14 +504,6 @@ func (f *SequenceFeatureView) WriteFeatures(data []map[string]interface{}, opts 
 			_ = playTimeValue
 		}
 
-	}
-
-	if o.InsertMode != "" {
-		for _, item := range data {
-			if item != nil {
-				item["__insert_mode__"] = o.InsertMode
-			}
-		}
 	}
 
 	f.featureViewDao.WriteFeatures(data)

--- a/domain/write_option.go
+++ b/domain/write_option.go
@@ -1,0 +1,55 @@
+package domain
+
+// WriteOptions controls per-call behavior of FeatureView.WriteFeatures.
+//
+// Options are immutable from the caller's perspective and only consumed by
+// the FeatureView implementation; they exist primarily so that new write
+// modes (such as the synchronous /write_direct path) can be added without
+// breaking the public WriteFeatures signature.
+type WriteOptions struct {
+	// Direct routes the call to the FeatureDB /write_direct endpoint.
+	//
+	// Semantics differ from the default async path:
+	//   - the request is sent immediately and returns synchronously;
+	//   - the in-memory ticker buffer is bypassed entirely;
+	//   - only KV-typed feature tables backed by FeatureDB are supported;
+	//   - only the FullRowWrite mode is accepted (PartialFieldWrite is rejected).
+	// Non-FeatureDB DAOs return an error when this option is set.
+	Direct bool
+
+	// InsertMode overrides the default write mode for the legacy /write
+	// path. Valid values are constants.FullRowWrite (default) and
+	// constants.PartialFieldWrite. When combined with Direct, only
+	// FullRowWrite is permitted.
+	InsertMode string
+}
+
+// WriteOption configures a single FeatureView.WriteFeatures invocation.
+type WriteOption func(*WriteOptions)
+
+// WithDirect routes the WriteFeatures call to FeatureDB's synchronous
+// /write_direct endpoint, bypassing the datahub-backed pipeline used by
+// the default /write path. Suitable for low-latency writes against KV
+// tables when the caller needs the per-row success/error result inline.
+func WithDirect() WriteOption {
+	return func(o *WriteOptions) { o.Direct = true }
+}
+
+// WithInsertMode sets the FeatureDB write_mode for this call.
+// Use constants.FullRowWrite (default) or constants.PartialFieldWrite.
+// Combining WithInsertMode(PartialFieldWrite) with WithDirect returns
+// an error because /write_direct only supports FullRowWrite.
+func WithInsertMode(mode string) WriteOption {
+	return func(o *WriteOptions) { o.InsertMode = mode }
+}
+
+// resolveWriteOptions folds a slice of WriteOption into a WriteOptions value.
+func resolveWriteOptions(opts []WriteOption) WriteOptions {
+	var o WriteOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&o)
+		}
+	}
+	return o
+}

--- a/domain/write_option_test.go
+++ b/domain/write_option_test.go
@@ -1,0 +1,145 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/api"
+	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/constants"
+	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/dao"
+)
+
+// recordingDao captures calls so tests can assert which DAO method the
+// FeatureView routed the write to.
+type recordingDao struct {
+	dao.UnimplementedFeatureViewDao
+	asyncCalled  int
+	directCalled int
+	lastData     []map[string]interface{}
+	directErr    error
+}
+
+func (r *recordingDao) WriteFeatures(data []map[string]interface{}) {
+	r.asyncCalled++
+	r.lastData = data
+}
+
+func (r *recordingDao) WriteFeaturesDirect(data []map[string]interface{}) error {
+	r.directCalled++
+	r.lastData = data
+	return r.directErr
+}
+
+// Satisfy the rest of the FeatureViewDao interface via embedded Unimplemented.
+var _ dao.FeatureViewDao = (*recordingDao)(nil)
+
+func TestResolveWriteOptions(t *testing.T) {
+	o := resolveWriteOptions(nil)
+	if o.Direct || o.InsertMode != "" {
+		t.Fatalf("zero-value WriteOptions expected, got %+v", o)
+	}
+
+	o = resolveWriteOptions([]WriteOption{WithDirect(), WithInsertMode(constants.FullRowWrite)})
+	if !o.Direct {
+		t.Errorf("WithDirect() should set Direct=true")
+	}
+	if o.InsertMode != constants.FullRowWrite {
+		t.Errorf("WithInsertMode should set InsertMode, got %q", o.InsertMode)
+	}
+}
+
+func TestBaseFeatureViewWriteFeatures_Default_Async(t *testing.T) {
+	rd := &recordingDao{}
+	fv := &BaseFeatureView{featureViewDao: rd}
+	data := []map[string]interface{}{{"id": "1"}}
+
+	if err := fv.WriteFeatures(data); err != nil {
+		t.Fatalf("default write should not return error, got %v", err)
+	}
+	if rd.asyncCalled != 1 || rd.directCalled != 0 {
+		t.Fatalf("expected async=1 direct=0, got async=%d direct=%d",
+			rd.asyncCalled, rd.directCalled)
+	}
+}
+
+func TestBaseFeatureViewWriteFeatures_WithDirect_RoutesDirect(t *testing.T) {
+	rd := &recordingDao{}
+	fv := &BaseFeatureView{featureViewDao: rd}
+	data := []map[string]interface{}{{"id": "1"}}
+
+	if err := fv.WriteFeatures(data, WithDirect()); err != nil {
+		t.Fatalf("WithDirect should not return error, got %v", err)
+	}
+	if rd.directCalled != 1 || rd.asyncCalled != 0 {
+		t.Fatalf("expected direct=1 async=0, got direct=%d async=%d",
+			rd.directCalled, rd.asyncCalled)
+	}
+}
+
+func TestBaseFeatureViewWriteFeatures_WithDirect_PropagatesError(t *testing.T) {
+	wantErr := errors.New("backend down")
+	rd := &recordingDao{directErr: wantErr}
+	fv := &BaseFeatureView{featureViewDao: rd}
+
+	err := fv.WriteFeatures([]map[string]interface{}{{"id": "1"}}, WithDirect())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected dao error to propagate, got %v", err)
+	}
+}
+
+func TestBaseFeatureViewWriteFeatures_WithDirect_RejectsPartialFieldWrite(t *testing.T) {
+	rd := &recordingDao{}
+	fv := &BaseFeatureView{featureViewDao: rd}
+
+	err := fv.WriteFeatures(
+		[]map[string]interface{}{{"id": "1"}},
+		WithDirect(), WithInsertMode(constants.PartialFieldWrite),
+	)
+	if err == nil {
+		t.Fatalf("WithDirect + PartialFieldWrite must error")
+	}
+	if rd.directCalled != 0 || rd.asyncCalled != 0 {
+		t.Fatalf("no DAO call expected on validation failure, got direct=%d async=%d",
+			rd.directCalled, rd.asyncCalled)
+	}
+}
+
+func TestBaseFeatureViewWriteFeatures_InsertModeStampsRows(t *testing.T) {
+	rd := &recordingDao{}
+	fv := &BaseFeatureView{featureViewDao: rd}
+	data := []map[string]interface{}{{"id": "1"}, {"id": "2"}}
+
+	if err := fv.WriteFeatures(data, WithInsertMode(constants.FullRowWrite)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, row := range rd.lastData {
+		if row["__insert_mode__"] != constants.FullRowWrite {
+			t.Errorf("row missing __insert_mode__ marker: %+v", row)
+		}
+	}
+}
+
+func TestSequenceFeatureViewWriteFeatures_WithDirect_NotSupported(t *testing.T) {
+	rd := &recordingDao{}
+	fv := &SequenceFeatureView{
+		FeatureView:    &api.FeatureView{},
+		featureViewDao: rd,
+	}
+
+	err := fv.WriteFeatures(
+		[]map[string]interface{}{{"item_id": "1"}},
+		WithDirect(),
+	)
+	if err == nil {
+		t.Fatalf("sequence FV must reject WithDirect")
+	}
+	if rd.directCalled != 0 {
+		t.Fatalf("dao.WriteFeaturesDirect should not be invoked for sequence FV")
+	}
+}
+
+// ensure context import is used to keep linters quiet across stubs that may be
+// added in the future; recordingDao's embedded Unimplemented already provides
+// context-aware methods, but referencing context here documents intent.
+var _ = context.Background


### PR DESCRIPTION
## 背景

服务端 [featuredb/featureservice/handlers/write_direct.go](https://code.alibaba-inc.com/pai_biz_arch/featuredb) 提供同步直写接口：绕过 datahub，直接 gRPC `BatchWriteKV`，仅支持 KV 表 + FullRowWrite，必须显式 `key_field`。SDK 现有 `/write` 路径走 50ms ticker 异步缓冲，语义上无法同步等结果。

## 修改内容

引入 per-call WriteOption 机制，新增 `WithDirect()` 触发同步直写，**保持 API 面向后兼容**（variadic 0-arg 调用无破坏）：

- **domain**：新增 `WriteOptions` / `WithDirect` / `WithInsertMode` 函数式 option；`FeatureView.WriteFeatures` 改为 variadic 并返回 `error`；`WriteFeaturesWithInsertMode` 转发到新签名以保持现有调用兼容
- **dao 接口层**：`FeatureViewDao` 新增 `WriteFeaturesDirect`；`UnimplementedFeatureViewDao` 默认返回 "not supported" 错误，hologres/igraph/tablestore 自动兜底
- **dao(featuredb)**：实现 `WriteFeaturesDirect`，请求体 `{content, write_mode: FullRowWrite, key_field: primaryKeyField}`，复用公网/VPC 地址降级逻辑，按 200 行批次切分，解析 `total_count`/`success_count`/`fail_keys`/`error_messages` 拼接错误
- **sequence FV**：显式拒绝 `WithDirect`（KKV 表服务端不接受）
- **tests**：新增 `domain/write_option_test.go` 覆盖 7 个用例（option 解析 / 默认异步 / WithDirect 路由 / 错误透传 / PartialFieldWrite 互斥 / insert mode / sequence FV 拒绝）

## 用法示例

```go
// 现有调用方式不变（异步缓冲）
fv.WriteFeatures(rows)

// 新增同步直写
if err := fv.WriteFeatures(rows, domain.WithDirect()); err != nil {
    log.Fatal(err)
}
```

## 验证

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./domain/ -run 'WriteOptions|WriteFeatures' -v` 7/7 PASS ✅

## 关联

Aone: https://aone.alibaba-inc.com/req/83204764
