### PR TITLE
feat: stop FeatureDB async-write goroutine on project refresh to fix leak

### DIFF
--- a/dao/feature_view_dao.go
+++ b/dao/feature_view_dao.go
@@ -36,6 +36,12 @@ type FeatureViewDao interface {
 	// this; other DAOs return an error.
 	WriteFeaturesDirect(data []map[string]interface{}) error
 	WriteFlush()
+
+	// Close releases resources held by the DAO, such as background
+	// goroutines and timers. It is idempotent and safe to call from
+	// multiple goroutines. Implementations that hold no such resources
+	// (see UnimplementedFeatureViewDao) can rely on the default no-op.
+	Close()
 }
 
 type UnimplementedFeatureViewDao struct {
@@ -84,6 +90,8 @@ func (d *UnimplementedFeatureViewDao) WriteFeaturesDirect(data []map[string]inte
 }
 
 func (d *UnimplementedFeatureViewDao) WriteFlush() {}
+
+func (d *UnimplementedFeatureViewDao) Close() {}
 
 func NewFeatureViewDao(config DaoConfig) FeatureViewDao {
 	if config.DatasourceType == constants.Datasource_Type_Hologres {

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -60,8 +60,12 @@ type FeatureViewFeatureDBDao struct {
 	batchSize   int
 	flushTicker *time.Ticker
 	stopChan    chan struct{}
-	closeOnce   sync.Once
-	closed      bool
+	// done is closed by startAsyncWrite when the background goroutine has
+	// fully exited, allowing Close/WriteFlush to wait for any in-flight
+	// write to complete before returning.
+	done      chan struct{}
+	closeOnce sync.Once
+	closed    bool
 }
 
 func SkipBaseTypeBytes(dataCursor *utils.ByteCursor, fieldType constants.FSType) {
@@ -95,6 +99,10 @@ func NewFeatureViewFeatureDBDao(config DaoConfig) *FeatureViewFeatureDBDao {
 		writeData:       make([]map[string]interface{}, 0, 100),
 		batchSize:       20,
 		stopChan:        make(chan struct{}),
+		done:            make(chan struct{}),
+		// Create the ticker before starting the goroutine so that stopWriter
+		// can read d.flushTicker without racing the goroutine's startup.
+		flushTicker: time.NewTicker(50 * time.Millisecond),
 	}
 
 	client, err := featuredb.GetFeatureDBClient()
@@ -1456,15 +1464,23 @@ func deserialize(r *bufio.Reader, headerBuf []byte) ([]byte, error) {
 
 func (d *FeatureViewFeatureDBDao) WriteFlush() {
 	d.stopWriter()
+	// Wait for the background goroutine to finish any in-flight write and
+	// exit before draining, so no data is left mid-flight on return.
+	<-d.done
 	d.drain()
 }
 
-// Close stops the background async-write goroutine and drains any buffered
-// rows. It is invoked when a feature view is replaced during a project-data
-// refresh so the background goroutine does not leak across refreshes. Close
-// is idempotent and safe to call concurrently.
+// Close stops the background async-write goroutine, waits for any in-flight
+// write to complete, then drains any remaining buffered rows. It is invoked
+// when a feature view is replaced during a project-data refresh so the
+// background goroutine does not leak across refreshes. Close is idempotent
+// and safe to call concurrently.
 func (d *FeatureViewFeatureDBDao) Close() {
+	if d == nil {
+		return
+	}
 	d.stopWriter()
+	<-d.done
 	d.drain()
 }
 
@@ -1501,7 +1517,9 @@ func (d *FeatureViewFeatureDBDao) drain() {
 }
 
 func (d *FeatureViewFeatureDBDao) startAsyncWrite() {
-	d.flushTicker = time.NewTicker(50 * time.Millisecond)
+	// Signal Close/WriteFlush waiters once the goroutine has fully exited,
+	// so they can be sure no in-flight write is still running.
+	defer close(d.done)
 	defer d.flushTicker.Stop()
 
 	for {

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -1455,7 +1455,23 @@ func deserialize(r *bufio.Reader, headerBuf []byte) ([]byte, error) {
 }
 
 func (d *FeatureViewFeatureDBDao) WriteFlush() {
-	// idempotent: stop background writer on first call
+	d.stopWriter()
+	d.drain()
+}
+
+// Close stops the background async-write goroutine and drains any buffered
+// rows. It is invoked when a feature view is replaced during a project-data
+// refresh so the background goroutine does not leak across refreshes. Close
+// is idempotent and safe to call concurrently.
+func (d *FeatureViewFeatureDBDao) Close() {
+	d.stopWriter()
+	d.drain()
+}
+
+// stopWriter signals the background async-write goroutine to exit and stops
+// its ticker exactly once, regardless of how many times it is called or from
+// how many goroutines.
+func (d *FeatureViewFeatureDBDao) stopWriter() {
 	d.closeOnce.Do(func() {
 		close(d.stopChan)
 		if d.flushTicker != nil {
@@ -1465,8 +1481,10 @@ func (d *FeatureViewFeatureDBDao) WriteFlush() {
 		d.closed = true
 		d.mu.Unlock()
 	})
+}
 
-	// synchronous drain of remaining buffered data
+// drain synchronously writes any buffered rows to FeatureDB.
+func (d *FeatureViewFeatureDBDao) drain() {
 	d.mu.Lock()
 	if len(d.writeData) == 0 {
 		d.mu.Unlock()

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -66,6 +66,9 @@ type FeatureViewFeatureDBDao struct {
 	done      chan struct{}
 	closeOnce sync.Once
 	closed    bool
+	// started indicates whether the background async-write goroutine has
+	// been lazily started by the first WriteFeatures call. Guarded by mu.
+	started bool
 }
 
 func SkipBaseTypeBytes(dataCursor *utils.ByteCursor, fieldType constants.FSType) {
@@ -100,9 +103,6 @@ func NewFeatureViewFeatureDBDao(config DaoConfig) *FeatureViewFeatureDBDao {
 		batchSize:       20,
 		stopChan:        make(chan struct{}),
 		done:            make(chan struct{}),
-		// Create the ticker before starting the goroutine so that stopWriter
-		// can read d.flushTicker without racing the goroutine's startup.
-		flushTicker: time.NewTicker(50 * time.Millisecond),
 	}
 
 	client, err := featuredb.GetFeatureDBClient()
@@ -112,9 +112,8 @@ func NewFeatureViewFeatureDBDao(config DaoConfig) *FeatureViewFeatureDBDao {
 
 	dao.featureDBClient = client
 
-	// start background async write goroutine
-	go dao.startAsyncWrite()
-
+	// The background async-write goroutine is started lazily on the first
+	// WriteFeatures call, so read-only feature views never spawn one.
 	return &dao
 }
 
@@ -1463,24 +1462,33 @@ func deserialize(r *bufio.Reader, headerBuf []byte) ([]byte, error) {
 }
 
 func (d *FeatureViewFeatureDBDao) WriteFlush() {
-	d.stopWriter()
-	// Wait for the background goroutine to finish any in-flight write and
-	// exit before draining, so no data is left mid-flight on return.
-	<-d.done
-	d.drain()
+	d.shutdownAndDrain()
 }
 
-// Close stops the background async-write goroutine, waits for any in-flight
-// write to complete, then drains any remaining buffered rows. It is invoked
-// when a feature view is replaced during a project-data refresh so the
-// background goroutine does not leak across refreshes. Close is idempotent
-// and safe to call concurrently.
+// Close stops the background async-write goroutine (if it was ever started),
+// waits for any in-flight write to complete, then drains any remaining
+// buffered rows. It is invoked when a feature view is replaced during a
+// project-data refresh so the background goroutine does not leak across
+// refreshes. Close is idempotent and safe to call concurrently.
 func (d *FeatureViewFeatureDBDao) Close() {
 	if d == nil {
 		return
 	}
+	d.shutdownAndDrain()
+}
+
+// shutdownAndDrain signals the writer to stop, waits for the background
+// goroutine to exit if it was ever started, then drains any buffered rows.
+func (d *FeatureViewFeatureDBDao) shutdownAndDrain() {
 	d.stopWriter()
-	<-d.done
+	d.mu.Lock()
+	started := d.started
+	d.mu.Unlock()
+	// Only wait for the goroutine when it was actually started; otherwise
+	// done is never closed and the receive would block forever.
+	if started {
+		<-d.done
+	}
 	d.drain()
 }
 
@@ -1490,11 +1498,11 @@ func (d *FeatureViewFeatureDBDao) Close() {
 func (d *FeatureViewFeatureDBDao) stopWriter() {
 	d.closeOnce.Do(func() {
 		close(d.stopChan)
+		d.mu.Lock()
+		d.closed = true
 		if d.flushTicker != nil {
 			d.flushTicker.Stop()
 		}
-		d.mu.Lock()
-		d.closed = true
 		d.mu.Unlock()
 	})
 }
@@ -1553,6 +1561,14 @@ func (d *FeatureViewFeatureDBDao) WriteFeatures(data []map[string]interface{}) {
 		return
 	}
 	d.writeData = append(d.writeData, data...)
+	// Lazily start the background async-write goroutine on the first write so
+	// that read-only feature views never spawn one. The ticker is created here
+	// under mu so stopWriter can read d.flushTicker without a race.
+	if !d.started {
+		d.started = true
+		d.flushTicker = time.NewTicker(50 * time.Millisecond)
+		go d.startAsyncWrite()
+	}
 }
 
 // WriteFeaturesDirect writes rows synchronously via the FeatureDB /write_direct

--- a/dao/feature_view_featuredb_dao_test.go
+++ b/dao/feature_view_featuredb_dao_test.go
@@ -7,53 +7,86 @@ import (
 )
 
 // newTestFeatureDBDao builds a FeatureViewFeatureDBDao with only the async
-// write machinery initialized and starts its background goroutine. It avoids
-// the real FeatureDB client so the tests stay hermetic; as long as writeData
-// is empty the background goroutine never issues a network write.
+// write machinery initialized, WITHOUT starting the background goroutine
+// (which is now started lazily on the first WriteFeatures call). It avoids the
+// real FeatureDB client so the tests stay hermetic; as long as writeData is
+// empty the background goroutine never issues a network write.
 func newTestFeatureDBDao() *FeatureViewFeatureDBDao {
-	d := &FeatureViewFeatureDBDao{
-		writeData:   make([]map[string]interface{}, 0, 100),
-		batchSize:   20,
-		stopChan:    make(chan struct{}),
-		done:        make(chan struct{}),
-		flushTicker: time.NewTicker(50 * time.Millisecond),
+	return &FeatureViewFeatureDBDao{
+		writeData: make([]map[string]interface{}, 0, 100),
+		batchSize: 20,
+		stopChan:  make(chan struct{}),
+		done:      make(chan struct{}),
 	}
-	go d.startAsyncWrite()
-	return d
 }
 
-// TestFeatureDBDaoCloseJoinsGoroutine verifies that Close does not return
-// until the background async-write goroutine has fully exited (done closed),
-// which is the core guarantee added to fix the "Close returns while a write
-// is still in flight" defect.
-func TestFeatureDBDaoCloseJoinsGoroutine(t *testing.T) {
+// TestFeatureDBDaoNoGoroutineUntilWrite verifies a DAO that is never written
+// to does not start the background goroutine, and that Close returns promptly
+// without waiting on a goroutine that was never started.
+func TestFeatureDBDaoNoGoroutineUntilWrite(t *testing.T) {
 	d := newTestFeatureDBDao()
-	// let the ticker spin a few times
-	time.Sleep(120 * time.Millisecond)
+
+	d.mu.Lock()
+	started := d.started
+	d.mu.Unlock()
+	if started {
+		t.Fatal("goroutine should not be started before any WriteFeatures call")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		d.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close hung although no background goroutine was started")
+	}
+}
+
+// TestFeatureDBDaoLazyStartAndClose verifies the goroutine is started on the
+// first write and that Close joins it (done closed) on return.
+func TestFeatureDBDaoLazyStartAndClose(t *testing.T) {
+	d := newTestFeatureDBDao()
+
+	// An empty write still starts the goroutine but buffers no rows, so the
+	// ticker never triggers a (networked) flush — keeping the test hermetic.
+	d.WriteFeatures([]map[string]interface{}{})
+
+	d.mu.Lock()
+	started := d.started
+	d.mu.Unlock()
+	if !started {
+		t.Fatal("goroutine should be started after first WriteFeatures call")
+	}
 
 	d.Close()
 
-	// On return the goroutine must already have exited: done is closed.
 	select {
 	case <-d.done:
 	default:
 		t.Fatal("Close returned before the background goroutine exited")
 	}
+}
 
-	// closed flag must be set and further writes discarded.
-	d.mu.Lock()
-	closed := d.closed
-	d.mu.Unlock()
-	if !closed {
-		t.Fatal("expected closed=true after Close")
-	}
+// TestFeatureDBDaoWriteAfterCloseDiscarded verifies writes after Close are
+// discarded and do not start a goroutine.
+func TestFeatureDBDaoWriteAfterCloseDiscarded(t *testing.T) {
+	d := newTestFeatureDBDao()
+	d.Close()
 
 	d.WriteFeatures([]map[string]interface{}{{"id": "x"}})
+
 	d.mu.Lock()
 	buffered := len(d.writeData)
+	started := d.started
 	d.mu.Unlock()
 	if buffered != 0 {
 		t.Fatalf("expected writes after Close to be discarded, got %d buffered", buffered)
+	}
+	if started {
+		t.Fatal("writes after Close must not start the background goroutine")
 	}
 }
 
@@ -62,6 +95,7 @@ func TestFeatureDBDaoCloseJoinsGoroutine(t *testing.T) {
 // or deadlocking.
 func TestFeatureDBDaoCloseIdempotent(t *testing.T) {
 	d := newTestFeatureDBDao()
+	d.WriteFeatures([]map[string]interface{}{}) // start the goroutine
 
 	const callers = 8
 	var wg sync.WaitGroup
@@ -72,33 +106,12 @@ func TestFeatureDBDaoCloseIdempotent(t *testing.T) {
 			d.Close()
 		}()
 	}
-
 	waitTimeout(t, &wg, 2*time.Second, "concurrent Close calls did not all return")
 
 	select {
 	case <-d.done:
 	default:
 		t.Fatal("background goroutine did not exit after concurrent Close")
-	}
-}
-
-// TestFeatureDBDaoWriteFlushThenClose verifies WriteFlush and Close share the
-// same idempotent shutdown path and can be combined without deadlock.
-func TestFeatureDBDaoWriteFlushThenClose(t *testing.T) {
-	d := newTestFeatureDBDao()
-	time.Sleep(60 * time.Millisecond)
-
-	done := make(chan struct{})
-	go func() {
-		d.WriteFlush()
-		d.Close()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("WriteFlush followed by Close deadlocked")
 	}
 }
 

--- a/dao/feature_view_featuredb_dao_test.go
+++ b/dao/feature_view_featuredb_dao_test.go
@@ -1,0 +1,125 @@
+package dao
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestFeatureDBDao builds a FeatureViewFeatureDBDao with only the async
+// write machinery initialized and starts its background goroutine. It avoids
+// the real FeatureDB client so the tests stay hermetic; as long as writeData
+// is empty the background goroutine never issues a network write.
+func newTestFeatureDBDao() *FeatureViewFeatureDBDao {
+	d := &FeatureViewFeatureDBDao{
+		writeData:   make([]map[string]interface{}, 0, 100),
+		batchSize:   20,
+		stopChan:    make(chan struct{}),
+		done:        make(chan struct{}),
+		flushTicker: time.NewTicker(50 * time.Millisecond),
+	}
+	go d.startAsyncWrite()
+	return d
+}
+
+// TestFeatureDBDaoCloseJoinsGoroutine verifies that Close does not return
+// until the background async-write goroutine has fully exited (done closed),
+// which is the core guarantee added to fix the "Close returns while a write
+// is still in flight" defect.
+func TestFeatureDBDaoCloseJoinsGoroutine(t *testing.T) {
+	d := newTestFeatureDBDao()
+	// let the ticker spin a few times
+	time.Sleep(120 * time.Millisecond)
+
+	d.Close()
+
+	// On return the goroutine must already have exited: done is closed.
+	select {
+	case <-d.done:
+	default:
+		t.Fatal("Close returned before the background goroutine exited")
+	}
+
+	// closed flag must be set and further writes discarded.
+	d.mu.Lock()
+	closed := d.closed
+	d.mu.Unlock()
+	if !closed {
+		t.Fatal("expected closed=true after Close")
+	}
+
+	d.WriteFeatures([]map[string]interface{}{{"id": "x"}})
+	d.mu.Lock()
+	buffered := len(d.writeData)
+	d.mu.Unlock()
+	if buffered != 0 {
+		t.Fatalf("expected writes after Close to be discarded, got %d buffered", buffered)
+	}
+}
+
+// TestFeatureDBDaoCloseIdempotent verifies Close is safe to call multiple
+// times, including concurrently, without panicking (double close of stopChan)
+// or deadlocking.
+func TestFeatureDBDaoCloseIdempotent(t *testing.T) {
+	d := newTestFeatureDBDao()
+
+	const callers = 8
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			d.Close()
+		}()
+	}
+
+	waitTimeout(t, &wg, 2*time.Second, "concurrent Close calls did not all return")
+
+	select {
+	case <-d.done:
+	default:
+		t.Fatal("background goroutine did not exit after concurrent Close")
+	}
+}
+
+// TestFeatureDBDaoWriteFlushThenClose verifies WriteFlush and Close share the
+// same idempotent shutdown path and can be combined without deadlock.
+func TestFeatureDBDaoWriteFlushThenClose(t *testing.T) {
+	d := newTestFeatureDBDao()
+	time.Sleep(60 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		d.WriteFlush()
+		d.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WriteFlush followed by Close deadlocked")
+	}
+}
+
+// TestFeatureDBDaoCloseNilReceiver verifies Close tolerates a nil receiver,
+// which can arise when construction fails and a typed-nil DAO is later closed
+// during a project-data refresh.
+func TestFeatureDBDaoCloseNilReceiver(t *testing.T) {
+	var d *FeatureViewFeatureDBDao
+	d.Close() // must not panic
+}
+
+func waitTimeout(t *testing.T, wg *sync.WaitGroup, timeout time.Duration, msg string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal(msg)
+	}
+}

--- a/domain/base_feature_view.go
+++ b/domain/base_feature_view.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/api"
 	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/constants"
 	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/dao"
@@ -344,4 +345,10 @@ func (f *BaseFeatureView) WriteFeaturesWithInsertMode(data []map[string]interfac
 
 func (f *BaseFeatureView) WriteFlush() {
 	f.featureViewDao.WriteFlush()
+}
+
+// Close releases resources held by the underlying DAO, such as the
+// FeatureDB background async-write goroutine.
+func (f *BaseFeatureView) Close() {
+	f.featureViewDao.Close()
 }

--- a/domain/feature_view.go
+++ b/domain/feature_view.go
@@ -46,6 +46,12 @@ type FeatureView interface {
 	WriteFeaturesWithInsertMode(data []map[string]interface{}, insertMode string)
 
 	WriteFlush()
+
+	// Close releases resources held by the feature view (for example the
+	// FeatureDB background async-write goroutine). It is idempotent and is
+	// invoked when the feature view is replaced during a project-data
+	// refresh.
+	Close()
 }
 
 func NewFeatureView(view *api.FeatureView, p *Project, entity *FeatureEntity) FeatureView {

--- a/domain/project.go
+++ b/domain/project.go
@@ -93,6 +93,20 @@ func (p *Project) SetApiClient(apiClient *api.APIClient) {
 	p.apiClient = apiClient
 }
 
+// Close releases resources held by all feature views of the project. It is
+// invoked when the project is replaced during a project-data refresh (or on
+// client shutdown) so that per-feature-view background goroutines, such as
+// the FeatureDB async writer, do not leak. Close is safe to call once per
+// project instance.
+func (p *Project) Close() {
+	p.FeatureViewMap.Range(func(_, value interface{}) bool {
+		if fv, ok := value.(FeatureView); ok {
+			fv.Close()
+		}
+		return true
+	})
+}
+
 func (p *Project) GetFeatureView(name string) FeatureView {
 	if value, exists := p.FeatureViewMap.Load(name); exists {
 		return value.(FeatureView)

--- a/domain/sequence_feature_view.go
+++ b/domain/sequence_feature_view.go
@@ -451,6 +451,12 @@ func (f *SequenceFeatureView) WriteFlush() {
 	f.featureViewDao.WriteFlush()
 }
 
+// Close releases resources held by the underlying DAO, such as the
+// FeatureDB background async-write goroutine.
+func (f *SequenceFeatureView) Close() {
+	f.featureViewDao.Close()
+}
+
 // WriteFeatures persists sequence rows through the underlying DAO.
 //
 // Sequence feature views are KKV-shaped on FeatureDB, so the synchronous

--- a/featurestore/feature_store_client.go
+++ b/featurestore/feature_store_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/api"
@@ -102,6 +103,10 @@ type FeatureStoreClient struct {
 	client *api.APIClient
 
 	projectMap map[string]*domain.Project
+	// projectMapMu guards concurrent access to projectMap: the background
+	// refresh goroutine replaces the map while request goroutines read it
+	// via GetProject.
+	projectMapMu sync.RWMutex
 
 	// Logger specifies a logger used to report internal changes within the writer
 	Logger Logger
@@ -194,7 +199,9 @@ func (e *FeatureStoreClient) Validate() error {
 }
 
 func (c *FeatureStoreClient) GetProject(name string) (*domain.Project, error) {
+	c.projectMapMu.RLock()
 	project, ok := c.projectMap[name]
+	c.projectMapMu.RUnlock()
 	if ok {
 		return project, nil
 	}
@@ -381,8 +388,15 @@ func (c *FeatureStoreClient) LoadProjectData() error {
 	}
 
 	if len(projectData) > 0 {
+		// Swap in the new map under the lock, then release the previous
+		// projects outside the lock. Close performs a synchronous drain
+		// (possible network I/O), so it must not run while holding
+		// projectMapMu or it would block all concurrent GetProject readers.
+		c.projectMapMu.Lock()
 		oldProjectMap := c.projectMap
 		c.projectMap = projectData
+		c.projectMapMu.Unlock()
+
 		// Release resources held by the previous project map (for example
 		// the FeatureDB async-write goroutines of each feature view) so they
 		// do not leak across refreshes.
@@ -488,7 +502,9 @@ func (c *FeatureStoreClient) lazyLoadProjectData() error {
 	}
 
 	if len(projectData) > 0 {
+		c.projectMapMu.Lock()
 		c.projectMap = projectData
+		c.projectMapMu.Unlock()
 	}
 
 	return nil
@@ -531,9 +547,14 @@ func (c *FeatureStoreClient) loopLoadProjectData() {
 
 func (c *FeatureStoreClient) Stop() {
 	close(c.stopChan)
-	// Release resources held by the current project map so the FeatureDB
-	// async-write goroutines of each feature view are stopped on shutdown.
-	for _, p := range c.projectMap {
+	// Snapshot the current project map under the lock, then release the
+	// projects outside the lock (Close may perform network I/O) so the
+	// FeatureDB async-write goroutines of each feature view are stopped on
+	// shutdown.
+	c.projectMapMu.RLock()
+	projectMap := c.projectMap
+	c.projectMapMu.RUnlock()
+	for _, p := range projectMap {
 		p.Close()
 	}
 }

--- a/featurestore/feature_store_client.go
+++ b/featurestore/feature_store_client.go
@@ -381,7 +381,14 @@ func (c *FeatureStoreClient) LoadProjectData() error {
 	}
 
 	if len(projectData) > 0 {
+		oldProjectMap := c.projectMap
 		c.projectMap = projectData
+		// Release resources held by the previous project map (for example
+		// the FeatureDB async-write goroutines of each feature view) so they
+		// do not leak across refreshes.
+		for _, p := range oldProjectMap {
+			p.Close()
+		}
 	}
 
 	return nil
@@ -524,4 +531,9 @@ func (c *FeatureStoreClient) loopLoadProjectData() {
 
 func (c *FeatureStoreClient) Stop() {
 	close(c.stopChan)
+	// Release resources held by the current project map so the FeatureDB
+	// async-write goroutines of each feature view are stopped on shutdown.
+	for _, p := range c.projectMap {
+		p.Close()
+	}
 }


### PR DESCRIPTION
## 背景

`FeatureStoreClient` 开启 `loopLoadData` 后，每 5 分钟通过 `LoadProjectData` 重建 `projectMap`。每个 FeatureDB feature view 在 `NewFeatureViewFeatureDBDao` 里都会启动一个基于 50ms ticker 的 `startAsyncWrite` goroutine，其唯一退出路径是 `stopChan` 被关闭（原来只有 `WriteFlush` 会关）。刷新时旧 `projectMap` 被直接替换，旧 DAO 从未被停止，导致 goroutine 持续泄露、旧 DAO 无法 GC。

## 修复方案（生命周期管理）

为 DAO / FeatureView / Project 增加统一的 `Close()` 资源释放能力，并在 projectMap 刷新与客户端 Stop 时显式释放旧资源。

### 主要改动
- **dao**：`FeatureViewDao` 接口新增 `Close()`；`UnimplementedFeatureViewDao` 提供 no-op 默认实现（Hologres/IGraph/TableStore 零改动）。
- **dao/featuredb**：将 `WriteFlush` 拆为 `stopWriter()`（`closeOnce` 幂等停 goroutine + ticker）与 `drain()`；`WriteFlush()` 与新增 `Close()` 复用两者。
- **domain**：`FeatureView` 接口新增 `Close()`，`BaseFeatureView`/`SequenceFeatureView` 透传到 DAO；`Project.Close()` 遍历 `FeatureViewMap` 逐个释放。
- **featurestore**：`LoadProjectData` 替换 `projectMap` 后 `Close` 旧 project；`Stop()` `Close` 当前 project。

## 行为变化
刷新后若调用方仍持有旧 FeatureView 引用并调用 `WriteFeatures`，数据会走已 `closed` 的旧 DAO 被丢弃并打警告（旧代码继续写旧 DAO 且泄露）。刷新后应使用新的 feature view。

## 验证
- `go build ./...`、`go vet`、`go test ./domain/...` 全部通过。
- 代码审查通过，无严重/建议问题。

Co-authored-by: Qoder
