### PR TITLE
fix: skip empty FeatureDB response blocks instead of panicking

### DIFF
--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/utils"
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 const (
@@ -146,6 +147,7 @@ func (d *FeatureViewFeatureDBDao) GetFeaturesWithContext(ctx context.Context, ke
 		wg.Add(1)
 		go func(ks []interface{}) {
 			defer wg.Done()
+			defer recoverReadPanic(errChan, "GetFeaturesWithContext")
 			var pkeys []string
 			for _, k := range ks {
 				pkeys = append(pkeys, utils.ToString(k, ""))
@@ -222,6 +224,14 @@ func (d *FeatureViewFeatureDBDao) GetFeaturesWithContext(ctx context.Context, ke
 					} else {
 						errChan <- err
 					}
+					return
+				}
+				if len(buf) == 0 {
+					log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
+					continue
+				}
+				if len(buf) < flatbuffers.SizeUOffsetT {
+					errChan <- fmt.Errorf("FeatureDB invalid block size: %d", len(buf))
 					return
 				}
 
@@ -718,6 +728,14 @@ func (d *FeatureViewFeatureDBDao) GetUserSequenceFeatureWithContext(ctx context.
 				}
 				return nil
 			}
+			if len(buf) == 0 {
+				log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
+				continue
+			}
+			if len(buf) < flatbuffers.SizeUOffsetT {
+				errChan <- fmt.Errorf("FeatureDB invalid block size: %d", len(buf))
+				return nil
+			}
 
 			kkvRecordBlock := fdbserverfb.GetRootAsKKVRecordBlock(buf, 0)
 
@@ -846,6 +864,7 @@ func (d *FeatureViewFeatureDBDao) GetUserSequenceFeatureWithContext(ctx context.
 		wg.Add(1)
 		go func(key interface{}) {
 			defer wg.Done()
+			defer recoverReadPanic(errChan, "GetUserSequenceFeatureWithContext")
 			properties := make(map[string]interface{})
 			var mu sync.Mutex
 
@@ -859,6 +878,7 @@ func (d *FeatureViewFeatureDBDao) GetUserSequenceFeatureWithContext(ctx context.
 				eventWg.Add(1)
 				go func(seqEvent string, seqConfigs []*api.SeqConfig, maxLen int, seqConfigsBehaviorFields map[string]struct{}) {
 					defer eventWg.Done()
+					defer recoverReadPanic(errChan, "GetUserSequenceFeatureWithContext")
 
 					// FeatureDB has processed the integration of online sequence features and offline sequence features
 					// Here we put the results into onlineSequences
@@ -1027,6 +1047,14 @@ func (d *FeatureViewFeatureDBDao) GetUserAggregatedSequenceFeatureWithContext(ct
 				}
 				return nil
 			}
+			if len(buf) == 0 {
+				log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
+				continue
+			}
+			if len(buf) < flatbuffers.SizeUOffsetT {
+				errChan <- fmt.Errorf("FeatureDB invalid block size: %d", len(buf))
+				return nil
+			}
 
 			kkvRecordBlock := fdbserverfb.GetRootAsKKVRecordBlock(buf, 0)
 
@@ -1158,6 +1186,7 @@ func (d *FeatureViewFeatureDBDao) GetUserAggregatedSequenceFeatureWithContext(ct
 		eventWg.Add(1)
 		go func(seqEvent string, seqConfigs []*api.SeqConfig, maxLen int, seqConfigsBehaviorFields map[string]struct{}) {
 			defer eventWg.Done()
+			defer recoverReadPanic(errChan, "GetUserAggregatedSequenceFeatureWithContext")
 
 			// FeatureDB has processed the integration of online sequence features and offline sequence features
 			// Here we put the results into onlineSequences
@@ -1335,6 +1364,14 @@ func (d *FeatureViewFeatureDBDao) GetUserBehaviorFeatureWithContext(ctx context.
 				}
 				return nil
 			}
+			if len(buf) == 0 {
+				log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
+				continue
+			}
+			if len(buf) < flatbuffers.SizeUOffsetT {
+				errChan <- fmt.Errorf("FeatureDB invalid block size: %d", len(buf))
+				return nil
+			}
 			kkvRecordBlock := fdbserverfb.GetRootAsKKVRecordBlock(buf, 0)
 
 			for i := 0; i < kkvRecordBlock.ValuesLength(); i++ {
@@ -1421,6 +1458,7 @@ func (d *FeatureViewFeatureDBDao) GetUserBehaviorFeatureWithContext(ctx context.
 		wg.Add(1)
 		go func(userId interface{}) {
 			defer wg.Done()
+			defer recoverReadPanic(errChan, "GetUserBehaviorFeatureWithContext")
 			innerresult := fetchDataFunc(userId)
 			outmu.Lock()
 			results = append(results, innerresult...)
@@ -1441,6 +1479,21 @@ func (d *FeatureViewFeatureDBDao) GetUserBehaviorFeatureWithContext(ctx context.
 	}
 
 	return results, nil
+}
+
+// recoverReadPanic reports a panic from a read goroutine as an error.
+func recoverReadPanic(errChan chan error, caller string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	err := fmt.Errorf("FeatureDB %s error: %v", caller, r)
+	log.Println(err)
+	// errChan holds one error per goroutine, so never block on a full channel
+	select {
+	case errChan <- err:
+	default:
+	}
 }
 
 func deserialize(r *bufio.Reader, headerBuf []byte) ([]byte, error) {

--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -227,7 +228,6 @@ func (d *FeatureViewFeatureDBDao) GetFeaturesWithContext(ctx context.Context, ke
 					return
 				}
 				if len(buf) == 0 {
-					log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
 					continue
 				}
 				if len(buf) < flatbuffers.SizeUOffsetT {
@@ -729,7 +729,6 @@ func (d *FeatureViewFeatureDBDao) GetUserSequenceFeatureWithContext(ctx context.
 				return nil
 			}
 			if len(buf) == 0 {
-				log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
 				continue
 			}
 			if len(buf) < flatbuffers.SizeUOffsetT {
@@ -1048,7 +1047,6 @@ func (d *FeatureViewFeatureDBDao) GetUserAggregatedSequenceFeatureWithContext(ct
 				return nil
 			}
 			if len(buf) == 0 {
-				log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
 				continue
 			}
 			if len(buf) < flatbuffers.SizeUOffsetT {
@@ -1365,7 +1363,6 @@ func (d *FeatureViewFeatureDBDao) GetUserBehaviorFeatureWithContext(ctx context.
 				return nil
 			}
 			if len(buf) == 0 {
-				log.Printf("FeatureDB %s/%s/%s: skip empty block", d.database, d.schema, d.table)
 				continue
 			}
 			if len(buf) < flatbuffers.SizeUOffsetT {
@@ -1488,7 +1485,7 @@ func recoverReadPanic(errChan chan error, caller string) {
 		return
 	}
 	err := fmt.Errorf("FeatureDB %s error: %v", caller, r)
-	log.Println(err)
+	log.Printf("%v\n%s", err, debug.Stack())
 	// errChan holds one error per goroutine, so never block on a full channel
 	select {
 	case errChan <- err:


### PR DESCRIPTION
## Problem

The FeatureDB streaming protocol frames each block as a 4-byte little-endian length prefix followed by the flatbuffers payload. `deserialize` returns an empty slice with a nil error when that prefix is 0, which the server sends when a request matches no data. Callers passed the empty buffer straight to `GetRootAs*`, and flatbuffers panicked with `index out of range [3] with length 0` while reading the root uoffset. Because the sequence readers run in per-key/per-event goroutines with no recover, the panic took down the whole host process.

## Changes

- Skip empty blocks (`len(buf) == 0`) and keep reading the stream, so later non-empty blocks in the same response are still processed. An empty block is the normal response for a request that matches no data, so it is skipped silently: logging every one of them would flood the log on a miss-heavy workload.
- Report a non-empty block shorter than a root uoffset (`0 < len(buf) < flatbuffers.SizeUOffsetT`) through `errChan` and stop reading that response. Such a block cannot be a valid frame, so continuing would hide stream corruption instead of surfacing it.
- Applied to all four read paths: `GetFeaturesWithContext`, `GetUserSequenceFeatureWithContext`, `GetUserAggregatedSequenceFeatureWithContext` and `GetUserBehaviorFeatureWithContext`.
- A length check alone cannot prove a non-empty block is a well-formed flatbuffer, so also recover in the five read goroutines and report the failure through `errChan`, which the existing error handling already surfaces to the caller. The recovered panic is logged together with `debug.Stack()`, otherwise the crash site is lost and a recovered panic becomes hard to diagnose.

## Notes on the recover

- `recoverReadPanic` is deferred after `wg.Done()`, so it runs before it: the error is always sent before the caller closes `errChan`, never after.
- It sends with a non-blocking `select`, because the outer goroutines are not part of the `errChan` capacity budget. A full channel drops the error instead of blocking `wg.Wait()` forever; the panic is still logged.

## Verification

- `gofmt -l dao/` reports nothing
- `go build ./...` passes
- `go vet ./dao/` passes
