### PR TITLE
fix(dao): close response body on early returns in ScanAndIterateData

### DIFF
--- a/dao/feature_view_featuredb_dao.go
+++ b/dao/feature_view_featuredb_dao.go
@@ -2398,14 +2398,20 @@ func (d *FeatureViewFeatureDBDao) ScanAndIterateData(filter string, ch chan<- st
 					continue
 				}
 				if response.StatusCode != http.StatusOK {
+					response.Body.Close()
 					continue
 				}
 				_ts := utils.ToInt64(response.Header.Get("Next-Ts"), 0)
 				if _ts == 0 {
+					response.Body.Close()
 					continue
 				}
 				ts = _ts
-				reader, _ := ipc.NewReader(response.Body, ipc.WithAllocator(alloc))
+				reader, err := ipc.NewReader(response.Body, ipc.WithAllocator(alloc))
+				if err != nil {
+					response.Body.Close()
+					continue
+				}
 
 				innerReader := readerPool.Get().(*bytes.Reader)
 				for reader.Next() {


### PR DESCRIPTION
## Problem

In the polling goroutine of `FeatureViewFeatureDBDao.ScanAndIterateData`:

1. **Connection leak**: when the response status was not `200` or the `Next-Ts` header was absent, the loop did `continue` without closing `response.Body`. The loop runs every 5 seconds, so each failed round leaked one connection that could neither be reused nor released.
2. **Possible process crash**: `reader, _ := ipc.NewReader(...)` discarded the error. On failure `reader` is nil and the following `reader.Next()` panics inside the background goroutine, taking down the whole process.

## Changes

- Close `response.Body` before `continue` on both early-exit paths.
- Check the error from `ipc.NewReader`, close the body and skip the round on failure.

## Verification

- `go build ./...` passes
- `go vet ./dao/` passes

## Note (not addressed here)

`ts = _ts` is advanced before parsing, so a round that fails at `ipc.NewReader` silently skips that batch instead of retrying. Whether `ts` should only advance after a successful parse is a separate behavioural decision.